### PR TITLE
AzurLane wiki logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -210,6 +210,15 @@ img[alt^="WEB_FreeTier"]
 
 ================================
 
+azurlane.koumakan.jp
+
+CSS
+.mw-wiki-logo  {
+    background-image: url(/w/resources/assets/azurlogo.png?550ee);
+}
+
+================================
+
 baike.baidu.com
 
 INVERT


### PR DESCRIPTION
azurlane.koumakan.jp site was displaying it's logo with the inverted color scheme. This edit fixes it.